### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -24,7 +24,7 @@ jobs:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif ./...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -7,6 +7,9 @@ on:
   schedule:
   - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nsavinda/arcana-db-backup/security/code-scanning/25](https://github.com/nsavinda/arcana-db-backup/security/code-scanning/25)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient for the `actions/checkout` step, and no additional permissions are required for the other steps. This ensures that the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
